### PR TITLE
Add modern dashboard design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ backup/
 bin/
 db/
 sui
-web/html
 main
 tmp
 .sync*

--- a/web/html/assets/scripts.js
+++ b/web/html/assets/scripts.js
@@ -1,0 +1,4 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // Placeholder for future dynamic functionality
+    console.log('Dashboard loaded');
+});

--- a/web/html/assets/styles.css
+++ b/web/html/assets/styles.css
@@ -1,0 +1,11 @@
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.card {
+    border: none;
+}
+
+.navbar-brand {
+    font-weight: 600;
+}

--- a/web/html/index.html
+++ b/web/html/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>S-UI Dashboard</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="assets/styles.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="#">S-UI</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item"><a class="nav-link" href="#">Dashboard</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#">Settings</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#">Logout</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container">
+        <div class="row g-4">
+            <div class="col-md-4">
+                <div class="card text-center shadow-sm">
+                    <div class="card-body">
+                        <h5 class="card-title">Clients</h5>
+                        <p class="display-6" id="clientsCount">0</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="card text-center shadow-sm">
+                    <div class="card-body">
+                        <h5 class="card-title">Traffic</h5>
+                        <p class="display-6" id="trafficUsage">0 GB</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="card text-center shadow-sm">
+                    <div class="card-body">
+                        <h5 class="card-title">Status</h5>
+                        <p class="display-6" id="systemStatus">OK</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="assets/scripts.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove `web/html` from .gitignore so custom assets are kept
- create a minimal HTML dashboard layout
- add styles and JS placeholders for the redesign

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6872605b70bc8333bb945825028efae5