### PR TITLE
Remove obsolete context handling and panic recovery

### DIFF
--- a/core/box.go
+++ b/core/box.go
@@ -1,12 +1,11 @@
 package core
 
 import (
-	"context"
-	"fmt"
-	"io"
-	"os"
-	"s-ui/util/common"
-	"time"
+       "context"
+       "io"
+       "os"
+       "s-ui/util/common"
+       "time"
 
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/endpoint"
@@ -182,20 +181,13 @@ func NewBox(options Options) (*Box, error) {
 		} else {
 			tag = F.ToString(i)
 		}
-		outboundCtx := ctx
-		if tag != "" {
-			// TODO: remove this
-			outboundCtx = adapter.WithContext(outboundCtx, &adapter.InboundContext{
-				Outbound: tag,
-			})
-		}
-		err = outboundManager.Create(
-			outboundCtx,
-			router,
-			logFactory.NewLogger(F.ToString("outbound/", outboundOptions.Type, "[", tag, "]")),
-			tag,
-			outboundOptions.Type,
-			outboundOptions.Options,
+               err = outboundManager.Create(
+                       ctx,
+                       router,
+                       logFactory.NewLogger(F.ToString("outbound/", outboundOptions.Type, "[", tag, "]")),
+                       tag,
+                       outboundOptions.Type,
+                       outboundOptions.Options,
 		)
 		if err != nil {
 			return nil, common.NewError("initialize outbound["+F.ToString(i)+"] "+tag, err)
@@ -262,39 +254,23 @@ func NewBox(options Options) (*Box, error) {
 }
 
 func (s *Box) PreStart() error {
-	err := s.preStart()
-	if err != nil {
-		// TODO: remove catch error
-		defer func() {
-			v := recover()
-			if v != nil {
-				s.logger.Error(err.Error())
-				s.logger.Error("panic on early close: " + fmt.Sprint(v))
-			}
-		}()
-		s.Close()
-		return err
-	}
-	s.logger.Info("sing-box pre-started (", F.Seconds(time.Since(s.createdAt).Seconds()), "s)")
-	return nil
+       err := s.preStart()
+       if err != nil {
+               s.Close()
+               return err
+       }
+       s.logger.Info("sing-box pre-started (", F.Seconds(time.Since(s.createdAt).Seconds()), "s)")
+       return nil
 }
 
 func (s *Box) Start() error {
-	err := s.start()
-	if err != nil {
-		// TODO: remove catch error
-		defer func() {
-			v := recover()
-			if v != nil {
-				s.logger.Debug(err.Error())
-				s.logger.Error("panic on early start: " + fmt.Sprint(v))
-			}
-		}()
-		s.Close()
-		return err
-	}
-	s.logger.Info("sing-box started (", F.Seconds(time.Since(s.createdAt).Seconds()), "s)")
-	return nil
+       err := s.start()
+       if err != nil {
+               s.Close()
+               return err
+       }
+       s.logger.Info("sing-box started (", F.Seconds(time.Since(s.createdAt).Seconds()), "s)")
+       return nil
 }
 
 func (s *Box) preStart() error {

--- a/core/endpoint.go
+++ b/core/endpoint.go
@@ -1,11 +1,10 @@
 package core
 
 import (
-	"s-ui/logger"
-	"s-ui/util/common"
+       "s-ui/logger"
+       "s-ui/util/common"
 
-	"github.com/sagernet/sing-box/adapter"
-	"github.com/sagernet/sing-box/option"
+       "github.com/sagernet/sing-box/option"
 )
 
 func (c *Core) AddInbound(config []byte) error {
@@ -53,17 +52,13 @@ func (c *Core) AddOutbound(config []byte) error {
 		return err
 	}
 
-	outboundCtx := adapter.WithContext(c.GetCtx(), &adapter.InboundContext{
-		Outbound: outbound_config.Tag,
-	})
-
-	err = outbound_manager.Create(
-		outboundCtx,
-		router,
-		factory.NewLogger("outbound/"+outbound_config.Type+"["+outbound_config.Tag+"]"),
-		outbound_config.Tag,
-		outbound_config.Type,
-		outbound_config.Options)
+       err = outbound_manager.Create(
+               c.GetCtx(),
+               router,
+               factory.NewLogger("outbound/"+outbound_config.Type+"["+outbound_config.Tag+"]"),
+               outbound_config.Tag,
+               outbound_config.Type,
+               outbound_config.Options)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- simplify outbound setup by removing unused context metadata
- drop panic recovery wrappers from `Box` start routines
- clean up unused imports

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687274aa9e1483338a1b5a4549c9e796